### PR TITLE
Add delay to preserved state enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-persistent-fsm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Node Red node for implementing a finite state machine.",
   "dependencies": {
     "javascript-state-machine": "3.*"

--- a/state-machine.js
+++ b/state-machine.js
@@ -79,7 +79,8 @@ module.exports = function (RED) {
       if (statePropertyType === 'msg') {
         msg = {}
         RED.util.setMessageProperty(msg, stateProperty, node.fsm.state)
-        setTimeout( () => { node.send(msg); }, 100);
+        // Send preserved state delayed to give other nodes a chance to activate on flows:started
+        setTimeout( () => { node.send(msg); }, 4000)
       }
     }
 

--- a/state-machine.js
+++ b/state-machine.js
@@ -79,7 +79,7 @@ module.exports = function (RED) {
       if (statePropertyType === 'msg') {
         msg = {}
         RED.util.setMessageProperty(msg, stateProperty, node.fsm.state)
-        node.send(msg)
+        setTimeout( () => { node.send(msg); }, 100);
       }
     }
 

--- a/state-machine.js
+++ b/state-machine.js
@@ -80,7 +80,7 @@ module.exports = function (RED) {
         msg = {}
         RED.util.setMessageProperty(msg, stateProperty, node.fsm.state)
         // Send preserved state delayed to give other nodes a chance to activate on flows:started
-        setTimeout( () => { node.send(msg); }, 4000)
+        setTimeout( () => { node.send(msg); }, 8000)
       }
     }
 


### PR DESCRIPTION
This change gives the "enforce state" message an async delay (8 seconds) to allow other nodes in a flow a chance to activate. Previously, the node would send the message immediately which typically would bypass nodes that had not completed ".on" registration. This kept that state message from being processed by queue, break, and API-state nodes.

It might be a good idea to pair the "Enforce state" with an "after x seconds" configurable time so this can be tuned... but this fixes the main issue.