### PR TITLE
Add option to specify custom context for state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# node-red-contrib-persistent-fsm
+# node-red-contrib-reboot-persistent-fsm
 
 A Node-Red node that wraps around the [Javascript State Machine](https://www.npmjs.com/package/javascript-state-machine) to implement a [finite state machine](https://en.wikipedia.org/wiki/Finite-state_machine) for Node-Red.
 
-Combination of [DeanCording](https://github.com/DeanCording/node-red-contrib-state-machine)'s and [lutzer](https://github.com/lutzer/node-red-contrib-finite-statemachine)'s similar libraries with the following notable changes:
+An extension of [hufftheweevil](https://github.com/hufftheweevil/node-red-contrib-persistent-fsm/)'s persistent FSM, which is a non-reboot persistent combination of [DeanCording](https://github.com/DeanCording/node-red-contrib-state-machine)'s and [lutzer](https://github.com/lutzer/node-red-contrib-finite-statemachine)'s similar libraries with the following notable change:
+
+- Allows picking a custom variable to persist the FSM state with support of [Node-RED contexts](https://nodered.org/docs/user-guide/context) enabling reboot persistence
+
+As this is a simple fork of [hufftheweevil](https://github.com/hufftheweevil/node-red-contrib-persistent-fsm/)'s persistent FSM, the following features were introduced by them:
 
 - State can optionally persist during re-deployment of nodes.
 - Deprecated Node-RED events have been replaced.
 - Invalid transition error includes details of request.
 - Excellent input UI from [DeanCording](https://github.com/DeanCording) combined with simple graphical rendering from [lutzer](https://github.com/lutzer). Best of both worlds.
-
-**Note:** If you want to use this library instead of [node-red-contrib-state-machine](https://flows.nodered.org/node/node-red-contrib-state-machine), simply remove that node from your palette, then install this one. All node configuration should be saved.
 
 ### Usage
 
@@ -22,3 +24,5 @@ The node will always start in the first state on the state list (unless "Persist
 Global and flow context properties can be used as trigger inputs but state transitions will only occur when the node receives a message.
 
 The current state can be set to a msg property or stored as a flow or global context property. If the state output is set to a msg property, that property is set in the original message and passed through, otherwise no messages are output.
+
+Picking a custom persist cache allows selecting a variable in a reboot persistent [Node-RED context](https://nodered.org/docs/user-guide/context). Reading from this variable should not pose any issues - writing to it may impact the behavior of the state machine in unexpected ways, thus should be avoided in case of uncertainty.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "node-red-contrib-persistent-fsm",
-  "version": "1.2.0",
-  "lockfileVersion": 2,
+  "name": "node-red-contrib-reboot-persistent-fsm",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "node-red-contrib-persistent-fsm",
-      "version": "1.2.0",
+      "name": "node-red-contrib-reboot-persistent-fsm",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "javascript-state-machine": "3.*"
@@ -14,13 +14,6 @@
       "devDependencies": {}
     },
     "node_modules/javascript-state-machine": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
-      "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="
-    }
-  },
-  "dependencies": {
-    "javascript-state-machine": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
       "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-reboot-persistent-fsm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-reboot-persistent-fsm",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "javascript-state-machine": "3.*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-reboot-persistent-fsm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Node Red node for implementing a reboot persistent finite state machine.",
   "dependencies": {
     "javascript-state-machine": "3.*"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "node-red-contrib-persistent-fsm",
-  "version": "1.2.1",
-  "description": "A Node Red node for implementing a finite state machine.",
+  "name": "node-red-contrib-reboot-persistent-fsm",
+  "version": "1.0.0",
+  "description": "A Node Red node for implementing a reboot persistent finite state machine.",
   "dependencies": {
     "javascript-state-machine": "3.*"
   },
-  "author": "hufftheweevil",
+  "author": "xoh",
   "license": "MIT",
   "keywords": [
     "node-red",
@@ -13,15 +13,17 @@
     "state machine",
     "finite state machine",
     "state",
-    "transition"
+    "transition",
+    "persistent",
+    "context"
   ],
   "bugs": {
-    "url": "https://github.com/hufftheweevil/node-red-contrib-persistent-fsm/issues"
+    "url": "https://github.com/xoh/node-red-contrib-reboot-persistent-fsm/issues"
   },
-  "homepage": "https://github.com/hufftheweevil/node-red-contrib-persistent-fsm",
+  "homepage": "https://github.com/xoh/node-red-contrib-reboot-persistent-fsm",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hufftheweevil/node-red-contrib-persistent-fsm.git"
+    "url": "git+https://github.com/xoh/node-red-contrib-reboot-persistent-fsm.git"
   },
   "node-red": {
     "nodes": {

--- a/state-machine.html
+++ b/state-machine.html
@@ -69,6 +69,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     stroke: #000;
     stroke-dasharray: 5, 5;
   }
+
+  .hidden {
+    display: none;
+  }
 </style>
 <script type="text/javascript" src="fsm/graph.js" inline></script>
 <script type="text/javascript">
@@ -82,6 +86,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         triggerPropertyType: { value: 'msg', required: true },
         stateProperty: { value: 'payload', required: true },
         statePropertyType: { value: 'msg', required: true },
+        persistStore: { value: '', required: false },
+        persistStoreType: { value: 'flow', required: false },
+        persistStoreCustomized: { value: false },
         initialDelay: { value: '0', validate: RED.validators.regex(/^[0-9]*$/) },
         persistOnReload: { value: true },
         outputStateChangeOnly: { value: false },
@@ -125,6 +132,15 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       oneditprepare: function () {
         if (!this.hasOwnProperty('initialDelay')) this.initialDelay = '0' // Default value for legacy versions
 
+        if (!this.persistStoreType) {
+          this.persistStoreType = 'flow'
+        }
+        $('#node-input-persistStore').typedInput({
+          default: 'flow',
+          types: ['flow', 'global'],
+          typeField: $('#node-input-persistStoreType')
+        })
+
         if (!this.triggerPropertyType) {
           this.triggerPropertyType = 'msg'
         }
@@ -141,6 +157,24 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           default: 'msg',
           types: ['msg', 'flow', 'global'],
           typeField: $('#node-input-statePropertyType')
+        })
+
+        $('#node-input-persistOnReload').on('change', function() {
+          if ($('#node-input-persistOnReload:checked').val()) {
+            $('#persistStoreCustomized-row').removeClass("hidden")
+          } else {
+            $('#persistStoreCustomized-row').addClass("hidden")
+            $('#node-input-persistStoreCustomized').prop("checked", false)
+            $('#node-input-persistStoreCustomized').trigger("change")
+          }
+        })
+
+        $('#node-input-persistStoreCustomized').on('change', function() {
+          if ($('#node-input-persistStoreCustomized:checked').val()) {
+            $('#persistStore-row').removeClass("hidden")
+          } else {
+            $('#persistStore-row').addClass("hidden")
+          }
         })
 
         var statesList = $('#node-input-states-container')
@@ -438,6 +472,16 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       <label>&nbsp;</label>
       <input type="checkbox" id="node-input-persistOnReload" style="display: inline-block; width: auto; vertical-align: top;">
       <label for="node-input-persistOnReload" style="width: 70%;">Persist state on re-deploy</label>
+  </div>
+  <div class="form-row" id="persistStoreCustomized-row">
+      <label>&nbsp;</label>
+      <input type="checkbox" id="node-input-persistStoreCustomized" style="display: inline-block; width: auto; vertical-align: top;">
+      <label for="node-input-persistStoreCustomized" style="width: 70%;">Use custom persist cache</label>
+  </div>
+  <div class="form-row" id="persistStore-row">
+      <label for="node-input-persistStore">Custom Store</label>
+      <input type="text" id="node-input-persistStore" style="width:250px;">
+      <input type="hidden" id="node-input-persistStoreType">
   </div>
    <div class="form-row node-input-states-container-row">
       <label><i class="fa fa-list"></i> States</span></label>


### PR DESCRIPTION
The PR adds the optional setting to select where the FSM state should be persisted to. This allows users to, if their Node-RED environment has this configured, select a context that is reboot persistent (https://nodered.org/docs/user-guide/context).

The change is implemented in way that doesn't affect default behavior; using a custom persistence store is fully opt-in.